### PR TITLE
wording

### DIFF
--- a/Resources/it.lproj/schema.strings
+++ b/Resources/it.lproj/schema.strings
@@ -1,2 +1,2 @@
-"uk_org_marginal_qlvideo_framerate" = "Frequenza immagini";
+"uk_org_marginal_qlvideo_framerate" = "Freq. Fotogrammi";
 "uk_org_marginal_qlvideo_subtitles" = "Sottotitoli";

--- a/Resources/it.lproj/schema.strings
+++ b/Resources/it.lproj/schema.strings
@@ -1,2 +1,2 @@
-"uk_org_marginal_qlvideo_framerate" = "Frequenza dei foto.";
+"uk_org_marginal_qlvideo_framerate" = "Frequenza immagini";
 "uk_org_marginal_qlvideo_subtitles" = "Sottotitoli";


### PR DESCRIPTION
Better would be, but possibly too long:
– frequenza delle immagini
– frequenza dei fotogrammi

«foto.» is not an usual abbreviation for «fotogramma», but for «fotografia»