### PR TITLE
replace deprecated `brew cask` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 
 Alternatively, if you have [Homebrew](http://brew.sh/) installed, you can install using Homebrew [Cask](http://caskroom.io/):
 
-    brew cask install qlvideo
+    brew install --cask qlvideo
 
 Screenshots
 -----------


### PR DESCRIPTION
'brew cask' is deprecated, using 'brew --cask' instead
https://github.com/Homebrew/brew/pull/8899
https://formulae.brew.sh/cask/qlvideo#default