### PR TITLE
Add dynamic previews for VP8 and VP9 WebM videos

### DIFF
--- a/previewer/PreviewViewController.xib
+++ b/previewer/PreviewViewController.xib
@@ -3,6 +3,7 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.WebKit2IBPlugin" version="23504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +13,7 @@
                 <outlet property="sidebarCollection" destination="3dx-Gy-fyQ" id="Q5R-As-Txa"/>
                 <outlet property="snapshot" destination="htc-cm-SN2" id="kNk-dX-aF9"/>
                 <outlet property="view" destination="c22-O7-iKe" id="xvY-uO-s8O"/>
+                <outlet property="webView" destination="AS2-Sv-Of1" id="qEO-N7-1mI"/>
             </connections>
         </customObject>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
@@ -55,6 +57,14 @@
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" id="d9s-ZW-k0c"/>
                 </imageView>
+                <wkWebView wantsLayer="YES" allowsLinkPreview="NO" allowsMagnification="YES" id="AS2-Sv-Of1">
+                    <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <wkWebViewConfiguration key="configuration">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" video="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
             </subviews>
             <point key="canvasLocation" x="139" y="-36"/>
         </customView>

--- a/previewer/Snapshotter.h
+++ b/previewer/Snapshotter.h
@@ -61,5 +61,6 @@ typedef NS_ENUM(NSInteger, CoverArtMode)
 @property (nonatomic,assign,readonly) CGSize previewSize;
 @property (nonatomic,assign,readonly) NSInteger duration;
 @property (nonatomic,retain,readonly) NSString *title;
+@property (nonatomic,retain,readonly,nullable) NSString *videoCodec;
 
 @end

--- a/previewer/Snapshotter.m
+++ b/previewer/Snapshotter.m
@@ -596,4 +596,17 @@ void segv_handler(int signum)
     return data;
 }
 
+- (NSString*) videoCodec
+{
+    if (video_stream_idx < 0 || !dec_ctx)
+        return nil;
+        
+    AVStream *s = fmt_ctx->streams[video_stream_idx];
+    AVCodecParameters *params = s->codecpar;
+    if (!params)
+        return nil;
+    enum AVCodecID codecID = params->codec_id;
+    return @(avcodec_get_name(codecID));
+}
+
 @end

--- a/previewer/Snapshotter.m
+++ b/previewer/Snapshotter.m
@@ -598,7 +598,7 @@ void segv_handler(int signum)
 
 - (NSString*) videoCodec
 {
-    if (video_stream_idx < 0 || !dec_ctx)
+    if (video_stream_idx < 0 || !fmt_ctx)
         return nil;
         
     AVStream *s = fmt_ctx->streams[video_stream_idx];

--- a/previewer/previewer.entitlements
+++ b/previewer/previewer.entitlements
@@ -10,5 +10,7 @@
 	</array>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
As WebKit supports WebM video format for VP8 and VP9 codecs, we can create a WebView for these videos to provide a dynamic preview with playback controls, HDR support, etc., just like quick look natively supported video formats

WIP:
- The size of the preview in popup and finder get info needs adjustment
- Could add a option for users to opt out of dynamic preview and regress to static snapshots instead
- Performance optimization