### PR TITLE
Add HAP codec support (Hap1, Hap5, HapY, HapM, HapA)

### DIFF
--- a/videodecoder/Info.plist
+++ b/videodecoder/Info.plist
@@ -291,6 +291,38 @@
 				<string>MPEG-4 Video (MEncoder)</string>
 			</dict>
 
+			<!-- Vidvox HAP codecs -->
+			<dict>
+				<key>CodecType</key>
+				<string>Hap1</string>
+				<key>CodecName</key>
+				<string>HAP</string>
+			</dict>
+			<dict>
+				<key>CodecType</key>
+				<string>Hap5</string>
+				<key>CodecName</key>
+				<string>HAP Alpha</string>
+			</dict>
+			<dict>
+				<key>CodecType</key>
+				<string>HapY</string>
+				<key>CodecName</key>
+				<string>HAP Q</string>
+			</dict>
+			<dict>
+				<key>CodecType</key>
+				<string>HapM</string>
+				<key>CodecName</key>
+				<string>HAP Q Alpha</string>
+			</dict>
+			<dict>
+				<key>CodecType</key>
+				<string>HapA</string>
+				<key>CodecName</key>
+				<string>HAP Alpha Only</string>
+			</dict>
+
 			<!-- Fallback type set by formatreader -->
 			<dict>
 				<key>CodecType</key>

--- a/videodecoder/videodecoder.swift
+++ b/videodecoder/videodecoder.swift
@@ -40,6 +40,11 @@ class VideoDecoder: NSObject, MEVideoDecoder {
         0x4d50_3431: AV_CODEC_ID_MSMPEG4V1,  // 'MP41'
         0x4d50_3432: AV_CODEC_ID_MSMPEG4V2,  // 'MP42'
         0x4d50_3433: AV_CODEC_ID_MSMPEG4V3,  // 'MP43'
+        0x4861_7031: AV_CODEC_ID_HAP,  // 'Hap1'
+        0x4861_7035: AV_CODEC_ID_HAP,  // 'Hap5'
+        0x4861_7059: AV_CODEC_ID_HAP,  // 'HapY'
+        0x4861_704D: AV_CODEC_ID_HAP,  // 'HapM'
+        0x4861_7041: AV_CODEC_ID_HAP,  // 'HapA'
     ]
 
     // Supported pixel formats for QuickTime animation. Non-paletised only.
@@ -215,6 +220,10 @@ class VideoDecoder: NSObject, MEVideoDecoder {
                         }
                     }
                 }
+            case AV_CODEC_ID_HAP:
+                // HAP outputs RGB0 (Hap1/HapY), RGBA (Hap5/HapM), or GRAY8 (HapA).
+                // FFmpeg's hapdec.c sets pix_fmt internally; no extradata needed.
+                params.pointee.color_range = AVCOL_RANGE_JPEG
             default:
                 // Shouldn't get here
                 logger.error(


### PR DESCRIPTION
Add FiveCC mappings and codec info for all five Vidvox HAP variants:

- `Hap1` (HAP), `Hap5` (HAP Alpha), `HapY` (HAP Q), `HapM` (HAP Q Alpha), `HapA` (HAP Alpha Only)

### Changes

- **videodecoder/videodecoder.swift**: Added FourCC-to-`AV_CODEC_ID_HAP` mappings and a `case AV_CODEC_ID_HAP` setting `AVCOL_RANGE_JPEG` (HAP uses full-range output).
- **videodecoder/Info.plist**: Added `CodecInfo` entries for all five variants.

No extradata configuration needed — FFmpeg's `hapdec.c` handles pixel format selection internally (RGB0 for Hap1/HapY, RGBA for Hap5/HapM, GRAY8 for HapA).

### Testing

Official HAP samples: https://github.com/Vidvox/hap. Decoding verified via FFmpeg (Hap1 → PNG confirmed). Full QuickLook testing requires a signed build.